### PR TITLE
Fix report generation and rendering

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { height: 100vh; }
+      #root { height: 100%; }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,13 +21,13 @@ function App() {
         "--rm",
         ...["--entrypoint", "/bin/sh"],
         ...["-v", "joycelin79_newman-extension-desktop-extension:/tmp"],
-        "joycelin79/htmlreporter-with-template",
+        "joycelin79/htmlreporter-with-template:latest",
         "-c",
         `"newman run https://api.getpostman.com/collections/${collectionID}?apikey=${apiKey} ${
           environmentID
             ? `--environment https://api.getpostman.com/environments/${environmentID}?apikey=${apiKey}`
             : ""
-        } -r htmlextra --reporter-htmlextra-template /file.hbs"`,
+        } -r htmlextra --reporter-htmlextra-template /file.hbs; cat ./newman/*.html"`,
       ]);
       console.log(results);
       setHtml(results.stdout);

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -4,7 +4,7 @@ import React from "react";
 export const Header = () => (
     <>
         <Typography variant="h3">Postman Results</Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ mt: 2 }}>
+        <Typography variant="body1" color="text.secondary" sx={{ marginY: 2 }}>
             This desktop extension displays output from a Postman collection run.
         </Typography>
     </>

--- a/htmlreporter-with-template/Dockerfile
+++ b/htmlreporter-with-template/Dockerfile
@@ -1,3 +1,11 @@
-FROM dannydainton/htmlextra
+FROM postman/newman:alpine
+
+LABEL maintainer="Danny Dainton <dannydainton@gmail.com>"
+
+RUN npm install -g newman-reporter-htmlextra
+
+WORKDIR /etc/newman
 
 COPY file.hbs /
+
+ENTRYPOINT ["newman"]

--- a/htmlreporter-with-template/file.hbs
+++ b/htmlreporter-with-template/file.hbs
@@ -361,9 +361,9 @@ body.theme-light code {
     color: #000000!important;
 }
 .text-wrap {
-    word-wrap: break-word; 
-    min-width: 600px; 
-    max-width: 600px; 
+    word-wrap: break-word;
+    min-width: 600px;
+    max-width: 600px;
     white-space: normal;
 }
 </style>
@@ -1175,24 +1175,6 @@ body.theme-light code {
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{/eq}}
-
-<!-- Set slider initial position depending on the localstorage state -->
-
-<script>
-(function () {
-  var sliderChecked = true;
-  if (localStorage.getItem('theme') === 'theme-light') {
-    setTheme('theme-light');
-    sliderChecked = false;
-  } else {
-    setTheme('theme-dark');
-    sliderChecked = true;
-  }
-  $(document).ready( function () {
-    document.getElementById('slider').checked = sliderChecked;
-  });
-})();
-</script>
 
 <!-- Data Table Configuration -->
 


### PR DESCRIPTION
Hi @loopDelicious :wave:

I managed to have the report working! :smile: There was two problems.

First, the `joycelin79/htmlreporter-with-template` that is used to generate the report inherit from `dannydainton/htmlextra` which has been created in July 2021. It does not the latest version of the `newman-reporter-htmlextra` library. So I copied the `dannydainton/htmlextra` Dockerfile inside `htmlreporter-with-template/Dockerfile` so that it contains a recent version of the library. Now the command works fine, the report is generated.

The second issue, was that the newman command ran by the image creates a file with the output. The `stdout` property from the returned object of the `ddClient.docker.cli.exec` is empty. I added a `cat` at the end of the command, and now it works :)

From there I was able to improve the rendering of the report displayed as you can see in the screenshot :)

<img width="1792" alt="Screenshot 2022-08-26 at 15 01 20" src="https://user-images.githubusercontent.com/212269/186909289-a2e359c6-0091-4890-a3c5-ee619ce4c2b8.png">


<img width="1792" alt="Screenshot 2022-08-26 at 15 02 13" src="https://user-images.githubusercontent.com/212269/186909437-107c65db-93b1-4a8c-8f32-bb1271b0dfa0.png">

