### PR TITLE
Persist API Key when reopening the extension

### DIFF
--- a/client/src/ApiContext.tsx
+++ b/client/src/ApiContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, FC, useContext, useState } from "react";
+
+interface IApiContext {
+    apiKey: string,
+    setApiKey: (v: string) => void,
+}
+const ApiContext = createContext<IApiContext>({
+    apiKey: '',
+    setApiKey: () => undefined,
+});
+
+const LOCAL_STORAGE_KEY = 'newman::apiKey';
+
+export const ApiContextProvider: FC = ({children}) => {
+    const [apiKey, setApiKey] = useState(localStorage.getItem(LOCAL_STORAGE_KEY) || '');
+    const setApiKeyInLocalStorage = (value: string) => {
+        localStorage.setItem(LOCAL_STORAGE_KEY, value);
+        setApiKey(value);
+    }
+    return <ApiContext.Provider value={{apiKey, setApiKey: setApiKeyInLocalStorage}}>{children}</ApiContext.Provider>
+}
+
+export const useApiContext = () => useContext(ApiContext);

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -1,9 +1,14 @@
+import { Box } from "@mui/material";
 import Typography from "@mui/material/Typography/Typography";
 import React from "react";
+import { LogoutButton } from "./LogoutButton";
 
 export const Header = () => (
     <>
-        <Typography variant="h3">Newman</Typography>
+        <Box display="flex" alignItems="center" justifyContent="space-between" width="100%">
+            <Typography variant="h3">Newman</Typography>
+            <LogoutButton />
+        </Box>
         <Typography variant="body1" color="text.secondary" sx={{ marginY: 2 }}>
             This desktop extension displays output from a Postman collection run.
         </Typography>

--- a/client/src/LogoutButton.tsx
+++ b/client/src/LogoutButton.tsx
@@ -1,0 +1,13 @@
+import { LogoutOutlined } from "@mui/icons-material"
+import { Button } from "@mui/material"
+import { useApiContext } from "./ApiContext"
+
+export const LogoutButton = () => {
+    const {apiKey, setApiKey} = useApiContext();
+
+    if (!apiKey) return null;
+
+    return (
+        <Button endIcon={<LogoutOutlined/>} variant="outlined" onClick={() => setApiKey('')}>Logout</Button>
+    )
+}

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -4,6 +4,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { DockerMuiThemeProvider } from "@docker/docker-mui-theme";
 
 import App from './App';
+import { ApiContextProvider } from "./ApiContext";
 
 ReactDOM.render(
     <React.StrictMode>
@@ -14,7 +15,9 @@ ReactDOM.render(
     */}
         <DockerMuiThemeProvider>
             <CssBaseline />
-            <App />
+            <ApiContextProvider>
+                <App />
+            </ApiContextProvider>
         </DockerMuiThemeProvider>
     </React.StrictMode>,
     document.getElementById("root")


### PR DESCRIPTION
Hi! Thank you for building this extension!

We wanted to collaborate and help you with the process to get this extension in the Marketplace, so I added this hopefully useful feature.

### What does this PR do

- Adds a new feature that **persist the API Key**, so if you go to another screen and then navigate to the extension again, you don't need to introduce it again.
- It also adds a Logout button that removes the API key.

Closes #4 