### PR TITLE
Update metadata.json to remove unnecessary fields

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,4 @@
 {
-  "name": "newman-extension",
-  "provider": "Postman",
   "icon": "icon-newman-docker.svg",
   "ui": {
     "dashboard-tab": {


### PR DESCRIPTION
Hi @loopDelicious, I've removed some unnecessary fields from the `metadata.json` field that are not needed anymore as our SDK has evolved.

I identified this when reviewing your extension for inclusion in the Marketplace using the `docker extension validate` command:

```
docker extension validate joycelin79/newman-extension:0.0.3
The extension image "joycelin79/newman-extension:0.0.3" is not valid. see errors:
- metadata.json: (root): Additional property name is not allowed
- metadata.json: (root): Additional property provider is not allowed
invalid extension image
```